### PR TITLE
Make the regex iterative and not a atomic match

### DIFF
--- a/is_mobile.rl
+++ b/is_mobile.rl
@@ -3,7 +3,6 @@
 */
 package ua
 
-// Returns a bool flag whether the agent is mobile agent and also returns the platform name
 func IsMobile(agent string) (bool, string) {
   var bytes []byte = make([]byte, len(agent))
   copy(bytes[:], agent)
@@ -18,23 +17,25 @@ func _isMobile(data []byte) (bool, string) {
   var mobile bool = true
 %% machine scanner;
 %% write data;
-  cs, p, pe := 0, 0, len(data)
+  cs, p, pe,eof := 0, 0, len(data), len(data)
   %%{
     action windows {os = "windows"; mobile = false}
     action winPhone {os = "windows"}
     action mac {os = "mac"; mobile = false}
-    action linux {os = "linux"; mobile = false}
+    action linux {os = "linux"; mobile = false;}
     action wii {os = "wii"}
     action playstation {os = "playstation"; mobile = false}
-    action ipad {os = "ipad"}
-    action ipod {os = "ipod"}
-    action iphone {os = "iphone"}
-    action android {os = "android"}
-    action blackberry {os = "blackberry"}
-    action samsung {os = "samsung"}
-    main := any* graph* space* punct* ('windows nt'i @windows|'windows phone'i @winPhone|'macintosh'i @mac|'linux'i @linux|'wii'i @wii|'playstation'i @playstation|'ipad'i @ipad|'ipod'i @ipod|'iphone'i @iphone|'android'i @android|'blackberry'i @blackberry|'samsung'i @samsung)+ @{ return mobile, os };
+    action ipad {os = "ipad"; mobile = true; goto end;}
+    action ipod {os = "ipod"; mobile = true; goto end;}
+    action iphone {os = "iphone"; mobile = true; goto end;}
+    action android {os = "android"; mobile = true; goto end;}
+    action blackberry {os = "blackberry"; mobile = true; goto end;}
+    action samsung {os = "samsung"; mobile = true; goto end;}
+    main := any* graph* space* punct* ('windows nt'i @windows|'windows phone'i @winPhone|'macintosh'i @mac|'linux'i @linux|'wii'i @wii|'playstation'i @playstation|'ipad'i @ipad|'ipod'i @ipod|'iphone'i @iphone|'android'i @android|'blackberry'i @blackberry|'samsung'i @samsung)+ %{ return mobile, os };
     write init;
     write exec;
   }%%
   return false, ""
+  end:
+    return true, os
 }

--- a/is_mobile.rl
+++ b/is_mobile.rl
@@ -2,7 +2,7 @@
   To check whether a given user agent is a mobile agent and if than which one
 */
 package ua
-
+// Returns a bool flag whether the agent is mobile agent and also returns the platform name
 func IsMobile(agent string) (bool, string) {
   var bytes []byte = make([]byte, len(agent))
   copy(bytes[:], agent)


### PR DESCRIPTION
Few UserAgents are placed tactically at weird positions and may make the ragel wrongly assume the  device to be a desktop rather than a mobile one.